### PR TITLE
(bugfix) remove socket from socket room on disconnect from lobby

### DIFF
--- a/server/sockets/lobbySockets.js
+++ b/server/sockets/lobbySockets.js
@@ -65,6 +65,8 @@ module.exports = function(socket, io) {
       lobby.removePlayer(socket.playerId);
       // update other players
       io.to(lobbyId).emit('updatePlayers', lobby.getPlayers());
+      // remove socket from socket room
+      socket.leave(lobbyId);
       // update lobbies for all players
       if (lobby.getPlayers().length === 0) {
         lobbies.removeLobby(lobbyId);


### PR DESCRIPTION
steps to reproduce with 1 player:
1) Start a game, then disconnect (refresh)
2) Enter a lobby, then disconnect (refresh)
3) Enter a lobby, then attempt to start a game. The Game will not load
